### PR TITLE
Use IndexMap for returning token amounts in removable_liquidity and claimable_fees

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -815,13 +815,12 @@ mod precision_pool {
         ///
         /// # Returns
         /// A tuple consisting of:
-        /// * The amount of token X that can be removed from the pool.
-        /// * The amount of token Y that can be removed from the pool.
+        /// * `IndexMap<ResourceAddress, Decimal>` - A map containing the resource addresses and the corresponding amount that can be removed from the pool.
         /// * The minimum removable fraction of the liquidity after hooks are executed.
         pub fn removable_liquidity(
             &self,
             lp_position_ids: Vec<NonFungibleLocalId>,
-        ) -> (Decimal, Decimal, Decimal) {
+        ) -> (IndexMap<ResourceAddress, Decimal>, Decimal) {
             let mut x_total_output = dec!(0);
             let mut y_total_output = dec!(0);
 
@@ -853,7 +852,13 @@ mod precision_pool {
                     false => HOOKS_MIN_REMAINING_BUCKET_FRACTION,
                 };
 
-            (x_total_output, y_total_output, minimum_removable_fraction)
+            (
+                IndexMap::from([
+                    (self.x_vault.resource_address(), x_total_output),
+                    (self.y_vault.resource_address(), y_total_output),
+                ]),
+                minimum_removable_fraction,
+            )
         }
 
         /// Removes liquidity from the pool and returns the corresponding amounts of token X and token Y.
@@ -1298,13 +1303,11 @@ mod precision_pool {
         /// * `lp_position_ids` - A vector of `NonFungibleLocalId` containing the IDs of liquidity positions for which fees are to be calculated.
         ///
         /// # Returns
-        /// A tuple containing two `Decimal`s:
-        /// - The first `Decimal` represents the total claimable `x` fees.
-        /// - The second `Decimal` represents the total claimable `y` fees.
+        /// - `IndexMap<ResourceAddress, Decimal>` - A map containing the resource addresses and their corresponding total claimable fees.
         pub fn claimable_fees(
             &self,
             lp_position_ids: Vec<NonFungibleLocalId>,
-        ) -> (Decimal, Decimal) {
+        ) -> IndexMap<ResourceAddress, Decimal> {
             let mut x_fees = dec!(0);
             let mut y_fees = dec!(0);
             for position_id in lp_position_ids {
@@ -1314,7 +1317,10 @@ mod precision_pool {
                 x_fees += x_claimable;
                 y_fees += y_claimable;
             }
-            (x_fees, y_fees)
+            IndexMap::from([
+                (self.x_vault.resource_address(), x_fees),
+                (self.y_vault.resource_address(), y_fees),
+            ])
         }
 
         /// Claims the accumulated fees for a given liquidity position.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1486,10 +1486,11 @@ mod precision_pool {
         /// * `lp_position_ids` - A vector of `NonFungibleLocalId` containing the IDs of liquidity positions for which fees are to be calculated.
         ///
         /// # Returns
-        /// A tuple containing two `Decimal`s:
-        /// - The first `Decimal` represents the total `x` fees.
-        /// - The second `Decimal` represents the total `y` fees.
-        pub fn total_fees(&self, lp_position_ids: Vec<NonFungibleLocalId>) -> (Decimal, Decimal) {
+        /// - `IndexMap<ResourceAddress, Decimal>` - A map containing the resource addresses and their corresponding total fees.
+        pub fn total_fees(
+            &self,
+            lp_position_ids: Vec<NonFungibleLocalId>,
+        ) -> IndexMap<ResourceAddress, Decimal> {
             let mut x_fees = dec!(0);
             let mut y_fees = dec!(0);
             for position_id in lp_position_ids {
@@ -1499,7 +1500,10 @@ mod precision_pool {
                 x_fees += x_total;
                 y_fees += y_total;
             }
-            (x_fees, y_fees)
+            IndexMap::from([
+                (self.x_vault.resource_address(), x_fees),
+                (self.y_vault.resource_address(), y_fees),
+            ])
         }
 
         /// Executes a swap, handling deposits and withdrawals based on the swap type.

--- a/test_helper/src/helper.rs
+++ b/test_helper/src/helper.rs
@@ -690,8 +690,8 @@ impl PoolTestHelper {
         self.getter("active_liquidity")
     }
 
-    pub fn total_liquidity(&mut self) -> &mut PoolTestHelper {
-        self.getter("total_liquidity")
+    pub fn vault_amounts(&mut self) -> &mut PoolTestHelper {
+        self.getter("vault_amounts")
     }
 
     pub fn input_fee_rate(&mut self) -> &mut PoolTestHelper {

--- a/test_helper/src/helper.rs
+++ b/test_helper/src/helper.rs
@@ -1062,14 +1062,16 @@ impl PoolTestHelper {
             .removable_liquidity(lp_positions)
             .registry
             .execute_expect_success(true);
-        let output_amounts: Vec<(Decimal, Decimal, Decimal)> =
+        let output_amounts: Vec<(IndexMap<ResourceAddress, Decimal>, Decimal)> =
             receipt.outputs("removable_liquidity");
 
         assert_eq!(
             output_amounts,
             vec![(
-                x_output_expected,
-                y_output_expected,
+                IndexMap::from([
+                    (self.x_address(), x_output_expected),
+                    (self.y_address(), y_output_expected),
+                ]),
                 minimum_removable_fraction
             )],
             "\nX Amount = {:?}, Y Amount {:?}",
@@ -1112,11 +1114,15 @@ impl PoolTestHelper {
             .claimable_fees(lp_positions)
             .registry
             .execute_expect_success(false);
-        let output_amounts: Vec<(Decimal, Decimal)> = receipt.outputs("claimable_fees");
+        let output_amounts: Vec<IndexMap<ResourceAddress, Decimal>> =
+            receipt.outputs("claimable_fees");
 
         assert_eq!(
             output_amounts,
-            vec![(x_fee_expected, y_fee_expected)],
+            vec![IndexMap::from([
+                (self.x_address(), x_fee_expected),
+                (self.y_address(), y_fee_expected),
+            ])],
             "\nX Amount = {:?}, Y Amount {:?}",
             x_fee_expected,
             y_fee_expected

--- a/test_helper/src/helper.rs
+++ b/test_helper/src/helper.rs
@@ -690,8 +690,8 @@ impl PoolTestHelper {
         self.getter("active_liquidity")
     }
 
-    pub fn vault_amounts(&mut self) -> &mut PoolTestHelper {
-        self.getter("vault_amounts")
+    pub fn total_liquidity(&mut self) -> &mut PoolTestHelper {
+        self.getter("total_liquidity")
     }
 
     pub fn input_fee_rate(&mut self) -> &mut PoolTestHelper {
@@ -1139,11 +1139,14 @@ impl PoolTestHelper {
             .total_fees(lp_position_ids)
             .registry
             .execute_expect_success(false);
-        let output_amounts: Vec<(Decimal, Decimal)> = receipt.outputs("total_fees");
+        let output_amounts: Vec<IndexMap<ResourceAddress, Decimal>> = receipt.outputs("total_fees");
 
         assert_eq!(
             output_amounts,
-            vec![(x_fee_expected, y_fee_expected)],
+            vec![IndexMap::from([
+                (self.x_address(), x_fee_expected),
+                (self.y_address(), y_fee_expected),
+            ])],
             "\nX Amount = {:?}, Y Amount {:?}",
             x_fee_expected,
             y_fee_expected


### PR DESCRIPTION
A caller of methods like `removable_liquidity, claimable_fees, total_fees` might not know which is x_address and y_address without two additional calls. Returning an `IndexMap` instead of a `Tuple` of `Decimal` gives directly the resource address and also by the order of elements what is `x` and `y`. This reduces transaction fees and avoids confusion since only one call is necessary now.