### PR TITLE
Separate x and y vault into liquidity and fees vaults and rename vault_amounts to total_liquidity 

### DIFF
--- a/test_helper/src/helper.rs
+++ b/test_helper/src/helper.rs
@@ -690,8 +690,8 @@ impl PoolTestHelper {
         self.getter("active_liquidity")
     }
 
-    pub fn vault_amounts(&mut self) -> &mut PoolTestHelper {
-        self.getter("vault_amounts")
+    pub fn total_liquidity(&mut self) -> &mut PoolTestHelper {
+        self.getter("total_liquidity")
     }
 
     pub fn input_fee_rate(&mut self) -> &mut PoolTestHelper {

--- a/tests/precision_pool_getters.rs
+++ b/tests/precision_pool_getters.rs
@@ -92,7 +92,7 @@ fn test_active_liquidity() {
 }
 
 #[test]
-fn test_vault_amounts() {
+fn test_total_liquidity() {
     let mut helper = PoolTestHelper::new();
     helper
         .instantiate_default(pdec!(1), false)
@@ -101,19 +101,19 @@ fn test_vault_amounts() {
 
     helper.add_liquidity_default(-500, 500, dec!(10), dec!(10));
 
-    helper.vault_amounts();
+    helper.total_liquidity();
 
-    let vault_amounts_expected = IndexMap::from([
+    let total_liquidity_expected = IndexMap::from([
         (helper.x_address(), dec!(10)),
         (helper.y_address(), dec!(10)),
     ]);
 
     let receipt = helper.registry.execute_expect_success(false);
 
-    let vault_amounts_returned: Vec<IndexMap<ResourceAddress, Decimal>> =
-        receipt.outputs("vault_amounts");
+    let total_liquidity_returned: Vec<IndexMap<ResourceAddress, Decimal>> =
+        receipt.outputs("total_liquidity");
 
-    assert_eq!(vault_amounts_returned, vec![vault_amounts_expected]);
+    assert_eq!(total_liquidity_returned, vec![total_liquidity_expected]);
 }
 
 #[test]


### PR DESCRIPTION
Previously principal liquidity and collected trading fees were stored in one combined vault.
This didn't allow for exact insights how much total liquidity is in the pool - only rough estimates including the unclaimed fees.
To solve that this PR uses different vaults for liquidity and fees allowing the total_liquidity function to return the exact amount.

The trade-off is that the flash loan now only uses the liquidity vault and not the fees anymore. However, I think this is fair and doesn't make a large difference.