### PR TITLE
Remove getter for active_liquidity

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -38,7 +38,6 @@ mod precision_pool {
             lp_address                  => PUBLIC;
             price_sqrt                  => PUBLIC;
             active_tick                 => PUBLIC;
-            active_liquidity            => PUBLIC;
             input_fee_rate              => PUBLIC;
             fee_protocol_share          => PUBLIC;
             flash_loan_fee_rate         => PUBLIC;
@@ -1643,16 +1642,6 @@ mod precision_pool {
         /// * The square root of the current price
         pub fn price_sqrt(&self) -> PreciseDecimal {
             self.price_sqrt
-        }
-
-        /// Retrieves the current active liquidity,
-        /// i.e. the virtual liquidity of the current subpool,
-        /// if any, otherwise zero.
-        ///
-        /// # Returns
-        /// * The current active liquidity
-        pub fn active_liquidity(&self) -> PreciseDecimal {
-            self.active_liquidity
         }
 
         /// Retrieves the last value of the input fee rate.

--- a/test_helper/src/helper.rs
+++ b/test_helper/src/helper.rs
@@ -686,10 +686,6 @@ impl PoolTestHelper {
         self.getter("price_sqrt")
     }
 
-    pub fn active_liquidity(&mut self) -> &mut PoolTestHelper {
-        self.getter("active_liquidity")
-    }
-
     pub fn total_liquidity(&mut self) -> &mut PoolTestHelper {
         self.getter("total_liquidity")
     }

--- a/tests/precision_pool_getters.rs
+++ b/tests/precision_pool_getters.rs
@@ -46,7 +46,6 @@ fn test_getters() {
         .execute_expect_success(false);
 
     helper.price_sqrt();
-    helper.active_liquidity();
     helper.input_fee_rate();
     helper.flash_loan_fee_rate();
 
@@ -68,27 +67,6 @@ fn test_getters() {
             vec![flash_loan_fee_rate]
         )
     );
-}
-
-#[test]
-fn test_active_liquidity() {
-    let active_liquidity_expected = pdec!(405.040831741441326012844520303631241918);
-
-    let mut helper = PoolTestHelper::new();
-    helper
-        .instantiate_default(pdec!(1), false)
-        .registry
-        .execute_expect_success(false);
-
-    helper.add_liquidity_default(-500, 500, dec!(10), dec!(10));
-
-    helper.active_liquidity();
-
-    let receipt = helper.registry.execute_expect_success(false);
-
-    let active_liquidity_returned: Vec<PreciseDecimal> = receipt.outputs("active_liquidity");
-
-    assert_eq!(active_liquidity_returned, vec![active_liquidity_expected]);
 }
 
 #[test]


### PR DESCRIPTION
Remove getter for active_liquidity because might be easily used in a wrong way by other dapps and is not of much use outside of the blueprint without access to the ticks.